### PR TITLE
Improve header layout and chart styling for better UX

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,13 @@ body {
   font-weight: 600;
 }
 
+/* Keep chart titles on a single line */
+.panel-chart .panel-title {
+  font-size: 0.95rem;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
 .panel-chart {
   padding: 8px 16px 16px 16px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -78,21 +78,29 @@ body {
 }
 
 .filter-control .MuiInputLabel-root {
+  position: static;
+  transform: none !important;
   color: var(--text-primary);
   font-weight: 700;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   letter-spacing: 0.2px;
+  margin: 0 0 6px 6px;
+  padding: 0;
 }
 
 .filter-control .MuiInputLabel-root.MuiInputLabel-shrink {
-  background: var(--surface);
-  padding: 0 4px;
-  z-index: 1;
+  transform: none !important;
+  background: transparent;
+  padding: 0;
 }
 
 .filter-control .MuiSelect-select {
   color: var(--text-primary);
   font-weight: 600;
+}
+
+.filter-control .MuiOutlinedInput-root {
+  margin-top: 0;
 }
 
 .dashboard-grid {

--- a/src/index.css
+++ b/src/index.css
@@ -127,6 +127,15 @@ body {
   white-space: nowrap;
 }
 
+/* Compact single-line variant for long titles */
+.panel-title-compact {
+  font-size: 0.9rem;
+  line-height: 1.15;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .panel-chart {
   padding: 8px 16px 16px 16px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,11 @@ body {
   background: transparent;
 }
 
+/* Preserve case for tab labels (e.g., MoHUA) */
+.role-tabs .MuiTab-root {
+  text-transform: none;
+}
+
 .header-filters {
   display: grid;
   grid-template-columns: repeat(4, 150px);

--- a/src/index.css
+++ b/src/index.css
@@ -78,7 +78,20 @@ body {
 }
 
 .filter-control .MuiInputLabel-root {
-  color: var(--text-secondary);
+  color: var(--text-primary);
+  font-weight: 700;
+  font-size: 0.9rem;
+  letter-spacing: 0.2px;
+}
+
+.filter-control .MuiInputLabel-root.MuiInputLabel-shrink {
+  background: var(--surface);
+  padding: 0 4px;
+  z-index: 1;
+}
+
+.filter-control .MuiSelect-select {
+  color: var(--text-primary);
   font-weight: 600;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -40,10 +40,10 @@ body {
 
 .header-toolbar {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
-  min-height: 64px;
-  padding: 0 24px;
+  min-height: 80px;
+  padding: 8px 24px;
 }
 
 .brand-title {

--- a/src/index.css
+++ b/src/index.css
@@ -63,7 +63,7 @@ body {
 
 .header-filters {
   display: grid;
-  grid-template-columns: repeat(4, minmax(140px, 1fr));
+  grid-template-columns: repeat(4, 150px);
   gap: 10px;
   align-items: center;
   flex: 1;
@@ -75,6 +75,11 @@ body {
   background: var(--surface);
   border-radius: 8px;
   width: 100%;
+}
+
+.filter-control .MuiInputLabel-root {
+  color: var(--text-secondary);
+  font-weight: 600;
 }
 
 .dashboard-grid {
@@ -190,6 +195,6 @@ body {
 
 @media (max-width: 899px) {
   .header-filters {
-    grid-template-columns: repeat(2, minmax(120px, 1fr));
+    grid-template-columns: repeat(2, 150px);
   }
 }

--- a/src/pages/MoHUA.jsx
+++ b/src/pages/MoHUA.jsx
@@ -84,7 +84,7 @@ export default function MoHUA() {
 
       <Grid item xs={12} md={6}>
         <Paper elevation={2} className="panel panel-chart">
-          <Typography variant="h6" className="panel-title">Resolution Rate (%) across Categories</Typography>
+          <Typography variant="h6" className="panel-title panel-title-compact">Resolution Rate (%) across Categories</Typography>
           <div className="chart-wrapper" role="img" aria-label="Stacked column resolution rate across categories">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={resRateByCat} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>

--- a/src/pages/MoHUA.jsx
+++ b/src/pages/MoHUA.jsx
@@ -7,7 +7,7 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend, CartesianGrid, ComposedChart, Line } from 'recharts';
+import { ResponsiveContainer, BarChart, Bar, LineChart, Line, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from 'recharts';
 import { mohuaData } from '../data/mock.js';
 
 import StatCard from '../components/StatCard.jsx';
@@ -16,6 +16,7 @@ export default function MoHUA() {
   const percentTargetData = mohuaData.percentTargetIssuesMonthly.map(d => ({ month: d.month, Achieved: d.achieved, Remaining: d.remaining }));
   const resRateByCat = mohuaData.resolutionRateByCategory.map(d => ({ category: d.category, Achieved: d.achieved, Gap: d.gap }));
   const qualityCombo = mohuaData.qualityComboMonthly;
+  const qualitySeries = qualityCombo.map(d => ({ ...d, overall: Math.round((d.infra + d.candd + d.garbage)/3) }));
 
   const lastTarget = percentTargetData[percentTargetData.length - 1]?.Achieved ?? 0;
   const avgResRate = Math.round(resRateByCat.reduce((s,d)=>s+d.Achieved,0)/resRateByCat.length);
@@ -104,19 +105,19 @@ export default function MoHUA() {
       <Grid item xs={12}>
         <Paper elevation={2} className="panel panel-chart">
           <Typography variant="h6" className="panel-title">Quality (%) across Categories</Typography>
-          <div className="chart-wrapper" role="img" aria-label="Combination chart for quality across categories">
+          <div className="chart-wrapper" role="img" aria-label="Line chart with trend for quality across categories">
             <ResponsiveContainer width="100%" height="100%">
-              <ComposedChart data={qualityCombo} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+              <LineChart data={qualitySeries} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="month" />
                 <YAxis domain={[0, 100]} />
                 <Tooltip />
                 <Legend />
-                <Bar dataKey="infra" fill="#6a1b9a" />
-                <Bar dataKey="candd" fill="#00838f" />
-                <Bar dataKey="garbage" fill="#ef6c00" />
-                <Line type="monotone" dataKey="infra" stroke="#4a148c" strokeWidth={2} dot={false} />
-              </ComposedChart>
+                <Line type="monotone" dataKey="infra" name="Infra" stroke="#1e88e5" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="candd" name="C&D" stroke="#43a047" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="garbage" name="Garbage" stroke="#fb8c00" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="overall" name="Trend" stroke="#263238" strokeWidth={3} dot={false} />
+              </LineChart>
             </ResponsiveContainer>
           </div>
         </Paper>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI/UX improvements to enhance visibility and readability of the dashboard:

- Make filter labels (Time, Month, City, Category) clearly visible above dropdown buttons
- Improve header layout and spacing for better visual hierarchy
- Fix text casing for "MoHUA" tab
- Enhance chart styling with modern design and better color schemes
- Ensure chart titles display on single lines

## Code Changes

**Header Layout Improvements:**
- Increased header height from 64px to 80px and adjusted padding
- Repositioned filter labels above dropdown buttons with static positioning
- Fixed dropdown width to 150px for consistent spacing
- Added text-transform: none for tab labels to preserve "MoHUA" casing

**Chart Enhancements:**
- Added compact title styling for long chart titles to prevent wrapping
- Replaced bar chart with line chart for Quality (%) across Categories
- Implemented modern color scheme with trend line overlay
- Added overall trend calculation and visualization

**Typography & Styling:**
- Enhanced filter label styling with better font weight and spacing
- Improved chart title formatting for single-line display
- Added responsive design considerations for mobile layouts

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/100382f4f6cb4f03b13447732dcfa8d2/vortex-haven)

👀 [Preview Link](https://100382f4f6cb4f03b13447732dcfa8d2-vortex-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>100382f4f6cb4f03b13447732dcfa8d2</projectId>-->
<!--<branchName>vortex-haven</branchName>-->